### PR TITLE
collapse MRI variable levels as done with SCID.

### DIFF
--- a/R/collapse_mri_levels.R
+++ b/R/collapse_mri_levels.R
@@ -1,0 +1,42 @@
+#' Collapse MRI levels
+#'
+#' @param dataset a [tibble::tbl_df]
+#' @inheritDotParams collapse_mri_level
+#'
+#' @returns a modified version of `dataset`
+#' @export
+#'
+collapse_mri_levels <- function(dataset, ...) {
+
+  mri_vars <- c(
+    "MCP-WM Hyperintensity",
+    "MRI: Cerebellar",
+    "MRI: Cerebral",
+    "Splenium (CC)-WM Hyperintensity"
+  )
+
+  dataset |>
+    mutate(
+      across(
+        .cols = any_of(mri_vars),
+        .fns = collapse_mri_level
+      )
+    )
+
+}
+
+#' Collapse levels of a single MRI variable
+#'
+#' @param x a MRI variable ([factor])
+#' @param levels [character] string vector of levels to collapse
+#'
+#' @returns a modified version of `x`
+#' @export
+#' @keywords internal
+#'
+collapse_mri_level <- function(x, levels = c("Moderate", "Severe")) {
+  x |>
+    forcats::fct_collapse(
+      "Moderate/Severe" = levels
+    )
+}

--- a/R/compile_biomarker_group_list.R
+++ b/R/compile_biomarker_group_list.R
@@ -32,7 +32,7 @@ compile_biomarker_group_list <- function(dataset) {
 
   parkinsonian_vars <-
     c(
-      "parkinsonian features",
+      # "parkinsonian features",
       "Masked faces",
       "Increased tone",
       "pill-rolling tremor",

--- a/analyses/ordinal-sustain.qmd
+++ b/analyses/ordinal-sustain.qmd
@@ -69,6 +69,7 @@ library(knitr)
 max_prob_correct <- .95
 
 do_collapse_scid_levels <- TRUE
+do_collapse_mri_levels <- TRUE
 
 fit_models <- TRUE
 run_cv <- TRUE
@@ -136,6 +137,10 @@ load("data/trax_gp34_v1.rda")
 
 if (do_collapse_scid_levels) {
   trax_gp34_v1 <- trax_gp34_v1 |> collapse_scid_levels()
+}
+
+if (do_collapse_mri_levels) {
+  trax_gp34_v1 <- trax_gp34_v1 |> collapse_mri_levels()
 }
 
 full_data <-

--- a/data-raw/ordinal-sustain.R
+++ b/data-raw/ordinal-sustain.R
@@ -38,6 +38,7 @@ run_cv =  TRUE
 # run_cv = FALSE
 
 do_collapse_scid_levels <- TRUE
+do_collapse_mri_levels <- TRUE
 
 N_startpoints = 10L
 use_parallel_startpoints = TRUE
@@ -83,6 +84,10 @@ output_folder =
 load("data/trax_gp34_v1.rda")
 if (do_collapse_scid_levels) {
   trax_gp34_v1 <- trax_gp34_v1 |> collapse_scid_levels()
+}
+
+if (do_collapse_mri_levels) {
+  trax_gp34_v1 <- trax_gp34_v1 |> collapse_mri_levels()
 }
 
 df =

--- a/data-raw/permutations.R
+++ b/data-raw/permutations.R
@@ -78,6 +78,9 @@ fit_models = TRUE
 run_cv =  TRUE
 # run_cv = FALSE
 
+do_collapse_scid_levels <- TRUE
+do_collapse_mri_levels <- TRUE
+
 N_startpoints = 10L
 N_S_max = 8L
 N_S_max_stratified = 1L
@@ -95,6 +98,14 @@ output_folder =
 ## ----------------------------------------------------------------------------------------------------
 # April 2024, main analysis now uses Trax/GP34 Visit 1 data replacing previous version using only GP34
 load("data/trax_gp34_v1.rda")
+if (do_collapse_scid_levels) {
+  trax_gp34_v1 <- trax_gp34_v1 |> collapse_scid_levels()
+}
+
+if (do_collapse_mri_levels) {
+  trax_gp34_v1 <- trax_gp34_v1 |> collapse_mri_levels()
+}
+
 v1_usable <-
   trax_gp34_v1 |>
   add_labels() |>


### PR DESCRIPTION
update biomarker group list to exclude 'Parkinsonian features'

apply collapse levels functions to ordinal-sustain.R and permutations.R